### PR TITLE
Adds Pester Image and PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Pull Request Template
+
+## 📲 What
+
+What have you implemented?
+
+## 🤔 Why
+
+Why have you implemented it?
+
+## 🛠 How
+
+How have you implemented it?
+
+## 👀 Evidence
+
+Link to builds/artifacts/etc.
+
+## 🕵️ How to test
+
+Notes for QA

--- a/image_definitions/pester/Dockerfile
+++ b/image_definitions/pester/Dockerfile
@@ -1,0 +1,4 @@
+FROM amidostacks/runner-pwsh
+
+# Install the PowerShell Gallery Pester Testing module
+RUN pwsh -NoProfile -Command "Install-Module -Name Pester -Scope AllUsers -Repository PSGallery -Force"

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -25,6 +25,12 @@ pipelines:
       IMAGE_NAME: amidostacks/runner-pwsh-java
       DOCKERFILE: ./image_definitions/java
 
+  build:pester:
+  - task: build:container
+    variables:
+      IMAGE_NAME: amidostacks/runner-pwsh-pester
+      DOCKERFILE: ./image_definitions/pester
+
   publish:
   - task: update:dashboard
 
@@ -36,5 +42,7 @@ pipelines:
     depends_on: [build:base]
   - pipeline: build:java
     depends_on: [build:base]
+  - pipeline: build:pester
+    depends_on: [build:base]
   - pipeline: publish
-    depends_on: [build:base, build:dotnet, build:java]
+    depends_on: [build:base, build:dotnet, build:java, build:pester]


### PR DESCRIPTION
Adds a Pester image for testing any Powershell modules/functions.

- A built pester Image in a temporary repository: https://hub.docker.com/repository/docker/williamamido/runner-pwsh-pester
- A build using the temporary registry image for Pester testing: https://amido-dev.visualstudio.com/Amido-Stacks/_build/results?buildId=20318&view=logs&j=527ac849-7c2e-5ca3-43fc-79206f5491f8&t=d53fb3dd-c32d-52d2-2317-746a0f41f01f

Adds a PR template as per `independent-runner` for PR's going forward.
