### PR TITLE
Adds openjdk-11-jdk for SonarScanner

### DIFF
--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -22,7 +22,9 @@ RUN curl https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
     rm /tmp/packages-microsoft-prod.deb
 
 RUN apt-get update && \
-    apt-get install -y dotnet-sdk-${DOTNET_VERSION}
+    apt-get install -y \
+    dotnet-sdk-${DOTNET_VERSION} \
+    openjdk-11-jdk
 
 # Install necessary dotnet tools
 RUN dotnet tool install dotnet-sonarscanner --version ${SONARSCANNER_VERSION} --tool-path ${TOOLPATH} && \


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Adds openjdk-11-jdk for SonarScanner

## 🤔 Why

So SonarScanner works natively without installing the JDK manually

## 🛠 How

Standard Dockerfile

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA
