### PR TITLE
Added new container image for Asciidoctor

### DIFF
--- a/image_definitions/asciidoctor/Dockerfile
+++ b/image_definitions/asciidoctor/Dockerfile
@@ -1,0 +1,22 @@
+FROM amidostacks/runner-pwsh:0.3.95-main
+
+ARG PANDOC_VERSION=2.17.1.1
+
+ENV GEM_FONTS_DIR=/usr/share/ruby-asciidoctor-pdf/data/fonts
+
+VOLUME ["/data"]
+
+# Install asciidoctor
+RUN apt-get update && \
+    apt-get install -y asciidoctor wget
+
+# Install the asciidoctor-pdf command
+RUN gem install --no-document asciidoctor-pdf
+
+# Install pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb -O /tmp/pandoc.deb && \
+    dpkg -i /tmp/pandoc.deb && \
+    rm -rf /tmp/pandoc.deb
+
+# Installed required gems
+RUN gem install rouge --no-doc

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -37,6 +37,12 @@ pipelines:
       IMAGE_NAME: amidostacks/runner-pwsh-golang
       DOCKERFILE: ./image_definitions/golang
 
+  build:asciidoctor:
+  - task: build:container
+    variables:
+      IMAGE_NAME: amidostacks/runner-pwsh-asciidoctor
+      DOCKERFILE: ./image_definitions/asciidoctor    
+
   publish:
   - task: update:dashboard
 
@@ -52,5 +58,7 @@ pipelines:
     depends_on: [build:base]
   - pipeline: build:golang
     depends_on: [build:base]
+  - pipeline: build:asciidoctor
+    depends_on: [build:base]
   - pipeline: publish
-    depends_on: [build:base, build:dotnet, build:java, build:python, build:golang]
+    depends_on: [build:base, build:dotnet, build:java, build:python, build:golang, build:asciidoctor]


### PR DESCRIPTION
## 📲 What

Added new Dockerfile to create image for Asciidoctor using the AIR base images

## 🤔 Why

The documentation for Stacks-CLI was using an identical image but from my personal Dockerhub org. This change gives an Amido image to be used.

## 🛠 How

Created a new image definition directory for asciidoctor and created a Dockerfile.

## 👀 Evidence

Image was built locally and tested with the `taskctl _docs` task of the Stacks CLI repo. The documentation was successfully created.

