### PR TITLE
Using Microsoft script for installation of Dotnet

### DIFF
--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -1,6 +1,7 @@
 # This image builds on the base image and installs .NET SDK
 # for building applications
 
+# FROM amidostacks/runner-pwsh
 FROM amidostacks/runner-pwsh
 
 # This image builds on the base image and installs .NET SDK
@@ -8,7 +9,7 @@ FROM amidostacks/runner-pwsh
 
 ARG SONARSCANNER_VERSION=5.4.1
 ARG REPORTGENERATOR_VERSION=5.0.2
-ARG DOTNET_VERSION=6.0
+ARG DOTNET_VERSION=6.0.200
 ARG TOOLPATH="/usr/local/dotnet"
 
 # Upate the PATH environment variable so that the tool can be found
@@ -17,18 +18,17 @@ ENV PATH="${TOOLPATH}:${PATH}"
 RUN apt-get -y install curl
 
 # Install the dotnet framework
-RUN curl https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -o /tmp/packages-microsoft-prod.deb && \
-    dpkg -i /tmp/packages-microsoft-prod.deb && \
-    rm /tmp/packages-microsoft-prod.deb
-
-RUN apt-get update && \
-    apt-get install -y \
-    dotnet-sdk-${DOTNET_VERSION} \
-    openjdk-11-jdk
+RUN curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
+    chmod +x /tmp/dotnet-install.sh && \
+    /tmp/dotnet-install.sh --install-dir /usr/bin --version ${DOTNET_VERSION}
 
 # Install necessary dotnet tools
 RUN dotnet tool install dotnet-sonarscanner --version ${SONARSCANNER_VERSION} --tool-path ${TOOLPATH} && \
     dotnet tool install dotnet-reportgenerator-globaltool --version ${REPORTGENERATOR_VERSION} --tool-path ${TOOLPATH}
+
+RUN apt-get update && \
+    apt-get install -y \
+    openjdk-11-jdk
 
 RUN apt-get -y remove curl && \
     apt-get -y autoremove

--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -15,7 +15,7 @@ ARG TOOLPATH="/usr/local/dotnet"
 # Upate the PATH environment variable so that the tool can be found
 ENV PATH="${TOOLPATH}:${PATH}"
 
-RUN apt-get -y install curl
+RUN apt-get update && apt-get -y install curl
 
 # Install the dotnet framework
 RUN curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \


### PR DESCRIPTION
## 📲 What

Modified the way that the Docker image is built by allowing the specific version of the Dotnet SDK to be specified

## 🤔 Why

Previously the Dockerfile was using the Linux package manage to install the framework, but by default this will install the latest version of Dotnet.

A lot of our projects use the `globa.json` file to specify the version of Dotnet to use and this is causing an issue when using the image to build.

## 🛠 How

Modified the install to download the install script from Microsoft and then run it with the specified version of the SDK. This is defaulted to `6.0.200` in the `DOTNET_VERSION` arg, but it can be overridden when building the image.

## 👀 Evidence

Test images have been created that have the SDK at the required version.

During the build of the image, the output shows that the 6.0.200 package is being downloaded and installed:
`docker build -t russellseymour/runner-pwsh-dotnet:rjs-2 -f .\image_definitions\dotnet\Dockerfile --build-arg DOTNET_VERSION=6.0.200 .\image_definitions\dotnet\`

![image](https://user-images.githubusercontent.com/791658/168268275-2f9ea884-7d3d-45c3-99be-b742b09fed7f.png)

Once the image has been created, it is possible to check the SDK that is installed.
`docker run -it --rm russellseymour/runner-pwsh-dotnet:rjs-2 dotnet --list-sdks`

![image](https://user-images.githubusercontent.com/791658/168268777-36fe1458-48fb-4cbd-ac23-8236b932040a.png)


## 🕵️ How to test

Notes for QA
