### PR TITLE
Fix issue where the `libhostxfr.so` library cannot be located

### DIFF
--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -15,12 +15,15 @@ ARG TOOLPATH="/usr/local/dotnet"
 # Upate the PATH environment variable so that the tool can be found
 ENV PATH="${TOOLPATH}:${PATH}"
 
+# Set the DOTNET_ROOT env var so that the reportgenerator binary works properly
+ENV DOTNET_ROOT="${TOOLPATH}"
+
 RUN apt-get update && apt-get -y install curl
 
 # Install the dotnet framework
 RUN curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
     chmod +x /tmp/dotnet-install.sh && \
-    /tmp/dotnet-install.sh --install-dir /usr/bin --version ${DOTNET_VERSION}
+    /tmp/dotnet-install.sh --install-dir ${TOOLPATH} --version ${DOTNET_VERSION}
 
 # Install necessary dotnet tools
 RUN dotnet tool install dotnet-sonarscanner --version ${SONARSCANNER_VERSION} --tool-path ${TOOLPATH} && \


### PR DESCRIPTION
## 📲 What

Modified the way in which the way dotnet is being installed

## 🤔 Why

After the dotnet version had been updated there was an issue with the `reportgenerator` command failing with the following error:



## 🛠 How

Changed the location that dotnet is installed into, now it is `/usr/local/dotnet` and added a new environment variable, called `DOTNET_ROOT` that points to this location.

This is the same location that the `reportgenerator` command is installed into.

## 👀 Evidence

This change ensures that the `reportgenerator` commands works as required,



## 🕵️ How to test

Notes for QA
