### PR TITLE
Correcting expression syntax to set the stability of the image

### DIFF
--- a/build/azDevOps/azuredevops-vars.yml
+++ b/build/azDevOps/azuredevops-vars.yml
@@ -16,7 +16,7 @@ variables:
 
   # Determine the "stability" of the image
   - name: stability
-    ${{ if or(eq(parameters.Build.SourceBranchName, 'master'), eq(parameters.Build.SourceBranchName, 'main'))}}:
+    ${{ if or(eq(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.SourceBranchName'], 'main'))}}:
       value: stable
     ${{ else }}:
       value: unstable


### PR DESCRIPTION
## 📲 What

Updated the epxresion to determine the stability flag

## 🤔 Why

The existing expression was not correct and all images were being tagged with `unstable` even if they had been built off the truink branch.

## 🛠 How

Changed the reference from `parameters.Build.SourceBranchName` to `variables['Build.SourceBranchName']`. This is all still within the template format for expressions.

## 👀 Evidence

Can only really test when it has been merged to check that the expression is now correct.

## 🕵️ How to test

Notes for QA
