### PR TITLE
Bump .NET and Maven versions

### DIFF
--- a/image_definitions/dotnet/Dockerfile
+++ b/image_definitions/dotnet/Dockerfile
@@ -9,7 +9,7 @@ FROM amidostacks/runner-pwsh
 
 ARG SONARSCANNER_VERSION=5.4.1
 ARG REPORTGENERATOR_VERSION=5.0.2
-ARG DOTNET_VERSION=6.0.200
+ARG DOTNET_VERSION=6.0.300
 ARG TOOLPATH="/usr/local/dotnet"
 
 # Upate the PATH environment variable so that the tool can be found

--- a/image_definitions/java/Dockerfile
+++ b/image_definitions/java/Dockerfile
@@ -4,7 +4,7 @@
 FROM amidostacks/runner-pwsh
 
 ARG JAVA_VERSION=11.0.13
-ARG MAVEN_VERSION=3.8.7
+ARG MAVEN_VERSION=3.8.8
 
 
 # Install dependencies


### PR DESCRIPTION
## 📲 What

Bumped the bundled version of .NET and Maven

## 🤔 Why

The constraints for the Stacks Dotnet packages have been updated to require a later version of .NET

The version of Maven that was specified was no longer available

## 🛠 How

Updated the version flag for these in the relevant Dockefiles.

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA
