### PR TITLE
Fixes issue with pushing images

### DIFF
--- a/build/azDevOps/azuredevops-vars.yml
+++ b/build/azDevOps/azuredevops-vars.yml
@@ -25,7 +25,7 @@ variables:
   - name: version_major
     value: 0
   - name: version_minor
-    value: 3
+    value: 4
   - name: version_revision
     value: $[counter(join(variables['version_major'], join('-', variables['version_minor'])), 0)]
   - name: version_semver

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -17,7 +17,7 @@ contexts:
         - PSModulePath=/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.62-kubectl
+        - amidostacks/runner-pwsh
         - pwsh
         - -NoProfile
         - -Command
@@ -46,7 +46,7 @@ contexts:
         - /app
         - --env-file
         - envfile        
-        - amidostacks/runner-pwsh-asciidoctor:latest
+        - amidostacks/runner-pwsh-asciidoctor
         - pwsh
         - -NoProfile
         - -Command

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -5,19 +5,16 @@ tasks:
     description: Create container image for application
     command:
       - Write-Host "Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
-      - Build-DockerImage -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
-    # Set variable IMAGE_NAME; i.e. stacks-api and DOCKER_BUILD_ARGS path i.e. ./image_definitions/base
+      - Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
 
   build:container:base:
     context: powershell
     description: Create Base image
     command:
-      # - Write-Host "Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
-      # - Build-DockerImage -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
       - |
         $env:PSModulePath += ":/home/vsts/modules"
         Import-Module AmidoBuild
-        Build-DockerImage -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
+        Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
 
   build:number:
     context: powershell_docker

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -4,7 +4,7 @@ tasks:
     context: powershell_docker
     description: Create container image for application
     command:
-      - Write-Host "Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
+      - Write-Host "Build-DockerImage -push -provider generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
       - Build-DockerImage -push -provider generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
     # Set variable IMAGE_NAME; i.e. stacks-api and DOCKER_BUILD_ARGS path i.e. ./image_definitions/base
 

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -5,16 +5,19 @@ tasks:
     description: Create container image for application
     command:
       - Write-Host "Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
-      - Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
+      - Build-DockerImage -push -provider generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
+    # Set variable IMAGE_NAME; i.e. stacks-api and DOCKER_BUILD_ARGS path i.e. ./image_definitions/base
 
   build:container:base:
     context: powershell
     description: Create Base image
     command:
+      # - Write-Host "Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs `"{{ .DOCKER_BUILD_ARGS }}`""
+      # - Build-DockerImage -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
       - |
         $env:PSModulePath += ":/home/vsts/modules"
         Import-Module AmidoBuild
-        Build-DockerImage -push -generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
+        Build-DockerImage -push -provider generic -Name {{ .IMAGE_NAME }} -buildargs "{{ .DOCKER_BUILD_ARGS }}" -latest
 
   build:number:
     context: powershell_docker


### PR DESCRIPTION
## 📲 What

Corrected the partameters passed to the `Build-DockerImage` cmdlet,

Bumped the minor version of the image

## 🤔 Why

During modification of the docker images, the `-push` argument had been left off the `Build-DockerImage` cmdlet so images are not being pushed to Docker Hub. Additionally the `-generic` argument has been modified to be `-provider generic`.

Bumping the version number as moving to Alpine is a big change.

## 🛠 How

Added `-push -provider generic` to the command for building the images.

Bumped the minor version in the variables for ADO pipeline.

## 👀 Evidence

The command to build the Docker images now looks like:

![image](https://github.com/amido/stacks-docker-images/assets/791658/e4526cf2-25e1-4b89-8c93-2287b5379cb1)

The images are now being published as expected:

![image](https://github.com/amido/stacks-docker-images/assets/791658/9a2398d8-91e7-42a9-8a56-84854e6a3e01)

As can be seen from the screenshot above the version is now 0.4.x, which has been changed in the pipeline:

![image](https://github.com/amido/stacks-docker-images/assets/791658/97437dac-9e01-487c-b2fe-30e2da5165b5)


## 🕵️ How to test

Notes for QA
