### PR TITLE
fix(build): verify docker image push before manifest creation

### DIFF
--- a/.github/prompts/address-pr-comments.prompt.md
+++ b/.github/prompts/address-pr-comments.prompt.md
@@ -1,0 +1,370 @@
+---
+agent: agent
+name: address-pr-comments
+description: Review and address all unresolved comments on a GitHub Pull Request, implement the requested changes, and commit the fixes.
+model: Auto (copilot)
+---
+
+# Address PR Comments Agent
+
+## Purpose
+
+This prompt guides an AI agent to review and address all **unresolved** comments on a GitHub Pull Request,
+implement the requested changes, and commit the fixes. When replying to review feedback,
+prefer a **single batched review submission** so reviewers receive one grouped notification instead
+of one notification per reply.
+
+## Prerequisites
+
+- GitHub CLI (`gh`) installed and authenticated
+- GitHub MCP server available with PR tools activated
+- Current branch matches the PR branch being addressed
+- Repository has uncommitted changes handled (stash or commit first)
+- Ensure `GH_PAGER` is set to `cat` to avoid pagination issues with less requiring user interaction
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+The user may provide:
+
+- A PR number (e.g., `26`)
+- A PR URL (e.g., `https://github.com/owner/repo/pull/26`)
+- Nothing (use current branch's PR)
+
+## Execution Flow
+
+### Phase 1: PR Discovery & Context Gathering
+
+1. **Determine the target PR**:
+   - If PR number provided in `$ARGUMENTS`, use it directly
+   - If PR URL provided, extract the PR number
+   - If no argument, detect PR from current branch:
+
+     ```bash
+     gh pr view --json number --jq '.number'
+     ```
+
+2. **Verify branch alignment**:
+   - Get current git branch: `git branch --show-current`
+   - Get PR head branch via `gh pr view <number> --json headRefName --jq '.headRefName'`
+   - If branches don't match, STOP and ask user to switch branches first
+
+3. **Fetch PR metadata**:
+
+   ```bash
+   gh pr view <number> --json title,body,state,reviewDecision,reviews,comments
+   ```
+
+### Phase 2: Retrieve All Review Comments
+
+1. **Get repository details**:
+
+   ```bash
+   gh repo view --json owner,name --jq '{owner: .owner.login, name: .name}'
+   ```
+
+2. **Get all PR review threads with resolution status**:
+
+   ```bash
+   # Replace OWNER, REPO, and PR_NUMBER with actual values
+   gh api graphql -f query='
+     query($owner: String!, $repo: String!, $pr: Int!) {
+       repository(owner: $owner, name: $repo) {
+         pullRequest(number: $pr) {
+           reviewThreads(first: 100) {
+             nodes {
+               id
+               isResolved
+               isOutdated
+               path
+               line
+               comments(first: 10) {
+                 nodes {
+                   databaseId
+                   body
+                   author { login }
+                   createdAt
+                 }
+               }
+             }
+           }
+         }
+       }
+     }
+   ' -f owner=OWNER -f repo=REPO -F pr=PR_NUMBER
+   ```
+
+3. **Filter to unresolved threads only**:
+   - `isResolved: false`
+   - Optionally include `isOutdated: false` to skip comments on old code
+
+### Phase 3: Analyze & Categorize Comments
+
+For each unresolved comment, categorize as:
+
+| Category          | Action Required                          |
+| ----------------- | ---------------------------------------- |
+| **Code Change**   | Modify source file at specified location |
+| **Documentation** | Update docs, comments, or Rustdoc        |
+| **Test Addition** | Add or modify test cases                 |
+| **Clarification** | Reply with explanation (no code change)  |
+| **Out of Scope**  | Mark for follow-up issue creation        |
+| **Disagree**      | Prepare response explaining rationale    |
+
+Create a structured todo list:
+
+```json
+{
+  "pr_number": 26,
+  "unresolved_count": 5,
+  "comments": [
+    {
+      "id": "thread_id",
+      "path": "src/lib.rs",
+      "line": 42,
+      "category": "Code Change",
+      "summary": "Add error handling for edge case",
+      "reviewer": "reviewer_username",
+      "action_plan": "Add match arm for empty input"
+    }
+  ]
+}
+```
+
+### Phase 4: Address Each Comment
+
+For each comment requiring code changes:
+
+1. **Read the relevant file context**:
+   - Use `read_file` tool to get surrounding context (±20 lines around the comment line)
+   - Understand the current implementation
+
+2. **Implement the fix**:
+   - Use `replace_string_in_file` or `multi_replace_string_in_file` for edits
+   - Follow Constitution principles (TDD, Clean Code, Security-First)
+   - If the fix requires new tests, add them first (Red-Green-Refactor)
+
+3. **Validate the change**:
+   - Run `cargo fmt` to ensure formatting
+   - Run `cargo clippy` to check for warnings
+   - Run relevant tests: `cargo test --workspace`
+
+4. **Prepare reply text** for each addressed comment:
+
+   ```markdown
+   Addressed in commit [SHA]:
+
+   - [Brief description of the change]
+   - [Any additional context or decisions made]
+   ```
+
+5. **Prepare batched review content**:
+   - Keep a per-thread reply for each unresolved thread
+   - Also prepare one overall review summary covering all addressed, clarified, and deferred items
+   - Keep broad rationale in the review summary and thread-specific details in the thread reply
+
+### Phase 5: Commit Changes
+
+1. **Stage changes by category** (prefer atomic commits):
+
+   ```bash
+   git add <files_for_comment_1>
+   git commit -m "fix(scope): address review comment - <summary>
+
+   Addresses review comment by @reviewer on PR #<number>:
+   <quote first line of comment>
+
+   Changes:
+   - <change 1>
+   - <change 2>"
+   ```
+
+2. **Alternative: Single commit for multiple related comments**:
+
+   ```bash
+   git add -A
+   git commit -m "fix: address PR #<number> review comments
+
+   Addresses the following review feedback:
+   - @reviewer1: <summary of fix 1>
+   - @reviewer2: <summary of fix 2>
+
+   Changes:
+   - <change 1>
+   - <change 2>
+   - <change 3>"
+   ```
+
+3. **Push changes**:
+
+   ```bash
+   git push origin HEAD
+   ```
+
+### Phase 6: Submit One Batched Review
+
+Do **not** post each reply individually unless batching is unavailable. Prefer one pending review,
+attach all thread replies to it, then submit once so GitHub sends one grouped notification.
+
+1. **Create a pending review**:
+
+   ```bash
+   # Replace PR_NODE_ID with the pull request GraphQL node id
+   gh api graphql -f query='
+      mutation($pullRequestId: ID!) {
+         addPullRequestReview(input: {pullRequestId: $pullRequestId}) {
+            pullRequestReview {
+               id
+            }
+         }
+      }
+   ' -f pullRequestId=PR_NODE_ID
+   ```
+
+2. **Add a reply for each unresolved thread to that pending review**:
+
+   ```bash
+   # Replace REVIEW_ID and THREAD_ID with GraphQL node ids
+   gh api graphql -f query='
+      mutation($reviewId: ID!, $threadId: ID!, $body: String!) {
+         addPullRequestReviewThreadReply(
+            input: {
+               pullRequestReviewId: $reviewId
+               pullRequestReviewThreadId: $threadId
+               body: $body
+            }
+         ) {
+            comment {
+               id
+            }
+         }
+      }
+   ' -f reviewId=REVIEW_ID -f threadId=THREAD_ID -f body='Addressed in commit abc1234.
+   - Added null check for empty input
+   - Updated tests to cover the edge case'
+   ```
+
+3. **Submit the review once all thread replies are attached**:
+
+   ```bash
+   gh api graphql -f query='
+      mutation($reviewId: ID!, $body: String!) {
+         submitPullRequestReview(
+            input: {
+               pullRequestReviewId: $reviewId
+               event: COMMENT
+               body: $body
+            }
+         ) {
+            pullRequestReview {
+               id
+               url
+            }
+         }
+      }
+   ' -f reviewId=REVIEW_ID -f body='Addressed PR feedback in the linked commit(s).
+
+   Summary:
+   - Resolved the requested code and test updates
+   - Added clarifications where code changes were not needed
+   - Deferred any out-of-scope items explicitly'
+   ```
+
+4. **Fallback only if batching is unavailable**:
+   - Prefer GitHub MCP review tools if they support pending reviews and thread replies
+   - If review batching is not available, fall back to individual replies and warn that multiple notifications may be sent
+   - Avoid mixing batched review replies and individual replies unless the tooling forces it
+
+### Phase 7: Summary Report
+
+Output a summary:
+
+```markdown
+## PR #<number> Review Comments Addressed
+
+**Total unresolved comments**: X
+**Addressed**: Y
+**Deferred/Out of scope**: Z
+
+### Commits Created
+
+| Commit  | Files                | Comments Addressed |
+| ------- | -------------------- | ------------------ |
+| abc1234 | src/lib.rs           | #1, #3             |
+| def5678 | tests/integration.rs | #2                 |
+
+### Review Submission
+
+- [x] Submitted one batched review for addressed threads
+- [x] Included per-thread replies in the review
+- [ ] Comment #3 by @reviewer3 - Deferred (created issue #XX)
+
+### Follow-up Items
+
+- Issue #XX: <out of scope item>
+```
+
+## Error Handling
+
+- **Branch mismatch**: Stop and instruct user to checkout correct branch
+- **Merge conflicts**: Stop and ask user to resolve conflicts first
+- **Test failures**: Report which tests fail and ask for guidance
+- **Unclear comments**: Ask for clarification before making changes
+- **Permissions issues**: Report and suggest manual gh auth refresh
+- **Batch review unsupported**: Fall back to individual replies only after stating that multiple notifications may be sent
+
+## Constitution Compliance
+
+This workflow MUST adhere to:
+
+- **Principle I (TDD)**: If adding functionality, write tests first
+- **Principle IV (Clean Code)**: Ensure changes are readable and maintainable
+- **Principle V (Security-First)**: Review any security implications of changes
+- **Commit Hygiene**: GPG-signed commits with conventional commit messages
+- **Branching Workflow**: Work on the correct feature branch
+
+## Example Usage
+
+```text
+User: Address comments on PR 26
+Agent:
+1. Fetching PR #26 details...
+2. Found 3 unresolved review threads
+3. Categorizing comments:
+   - Comment 1: Code change needed in src/routing.rs:142
+   - Comment 2: Documentation update in docs/USAGE.md
+   - Comment 3: Clarification question (will reply)
+4. Implementing fixes...
+5. Running validation (fmt, clippy, tests)...
+6. Committing changes...
+7. Submitting one batched review...
+8. Summary: 2 code changes committed, 1 clarification included in the batched review
+```
+
+## Quick Reference Commands
+
+```bash
+# View PR details
+gh pr view <number>
+
+# List all comments
+gh pr view <number> --comments
+
+# Get review threads (GraphQL)
+gh api graphql -f query='...'
+
+# Create a pending review
+gh api repos/{owner}/{repo}/pulls/{pr}/reviews --method POST
+
+# Submit a pending review
+gh api repos/{owner}/{repo}/pulls/{pr}/reviews/{review_id}/events --method POST -f event=COMMENT -f body="..."
+
+# Push and update PR
+git push origin HEAD
+
+# Re-request review after addressing comments
+gh pr edit <number> --add-reviewer <username>
+```

--- a/build/azDevOps/azuredevops-vars.yml
+++ b/build/azDevOps/azuredevops-vars.yml
@@ -50,6 +50,10 @@ variables:
   # Docker
   - name: DOCKER_IMAGE_TAG
     value: $(version_semver)
+  - name: DOCKER_MANIFEST_CHECK_RETRIES
+    value: 24
+  - name: DOCKER_MANIFEST_CHECK_DELAY_SECONDS
+    value: 10
 
   # GitHub Release
   - name: VERSION_NUMBER

--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -389,6 +389,8 @@ stages:
                 env:
                   DOCKER_IMAGE_NAME: ${{ stage.imageName }}
                   DOCKER_IMAGE_TAG: $(Build.BuildNumber)
+                  DOCKER_MANIFEST_CHECK_RETRIES: $(DOCKER_MANIFEST_CHECK_RETRIES)
+                  DOCKER_MANIFEST_CHECK_DELAY_SECONDS: $(DOCKER_MANIFEST_CHECK_DELAY_SECONDS)
                   DOCS_PATH: ${{ stage.docsPath }}
 
   - ${{ if or(eq(parameters['force_deploy'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:

--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -361,6 +361,7 @@ stages:
 
           - job: create_manifest
             displayName: Create Multi-Arch Manifest
+            condition: succeeded()
             dependsOn:
               - BuildImage_amd64
               - BuildImage_arm64

--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -78,15 +78,6 @@ parameters:
         imageName: ensono/eir-dotnet
         docsPath: dotnet
 
-      - stage: Go
-        displayName: "[CONTAINER] Go"
-        dependsOn:
-          - FoundationBuilder
-          - FoundationPowerShell
-        taskName: build:golang
-        imageName: ensono/eir-golang
-        docsPath: golang
-
       - stage: Inspec
         displayName: "[CONTAINER] Inspec"
         dependsOn:

--- a/build/azDevOps/docker-images.yml
+++ b/build/azDevOps/docker-images.yml
@@ -78,6 +78,15 @@ parameters:
         imageName: ensono/eir-dotnet
         docsPath: dotnet
 
+      - stage: Go
+        displayName: "[CONTAINER] Go"
+        dependsOn:
+          - FoundationBuilder
+          - FoundationPowerShell
+        taskName: build:golang
+        imageName: ensono/eir-golang
+        docsPath: golang
+
       - stage: Inspec
         displayName: "[CONTAINER] Inspec"
         dependsOn:

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -92,6 +92,7 @@ function Wait-ForDockerImagePush {
 
 try {
     $ErrorActionPreference = "Stop"
+    $loggedIn = $false
 
     # Enable experimental builds
     $env:DOCKER_CLI_AKV2_EXPERIMENTAL="enabled"
@@ -122,7 +123,8 @@ try {
 
     # Login to the specified container registry
     Write-Host ("Logging into registry: {0}" -f $registry)
-    Invoke-External -Command "docker login -u ${username} -p ${password} ${registry}" -Dryrun:$dryrun
+    Invoke-DockerRegistryLogin -Registry $registry -Username $username -Password $password -Dryrun:$dryrun
+    $loggedIn = -not $dryrun.IsPresent
 
     if (![string]::IsNullOrEmpty($tag)) {
         $tags += ("-t {0}" -f $image_name)
@@ -158,5 +160,9 @@ try {
     }
 }
 finally {
+    if ($loggedIn) {
+        Invoke-DockerRegistryLogout -Registry $registry
+    }
+
     $ErrorActionPreference = $previousErrorActionPreference
 }

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -34,16 +34,18 @@ param (
     # State that the script would run in dryrun and not to execute any commands
     $dryrun,
 
+    [ValidateRange(1, [int]::MaxValue)]
     [int]
     # Number of times to verify image exists in registry after push
     $PushVerifyRetries = 5,
 
+    [ValidateRange(0, [int]::MaxValue)]
     [int]
     # Delay in seconds between push verification attempts
     $PushVerifyDelaySeconds = 10
 )
 
-$ErrorActionPreference = "Stop"
+$previousErrorActionPreference = $ErrorActionPreference
 
 function Wait-ForDockerImagePush {
     param (
@@ -78,63 +80,70 @@ function Wait-ForDockerImagePush {
     }
 }
 
-# Enable experimental builds
-$env:DOCKER_CLI_AKV2_EXPERIMENTAL="enabled"
+try {
+    $ErrorActionPreference = "Stop"
 
-# Determine the arch based on the platform info
-switch ($platform) {
-    "linux/amd64" {
-        $arch = "amd64"
+    # Enable experimental builds
+    $env:DOCKER_CLI_AKV2_EXPERIMENTAL="enabled"
+
+    # Determine the arch based on the platform info
+    switch ($platform) {
+        "linux/amd64" {
+            $arch = "amd64"
+        }
+        "linux/arm64" {
+            $arch = "arm64"
+        }
     }
-    "linux/arm64" {
-        $arch = "arm64"
+
+    # Define default values for parameters not set
+    if ([string]::IsNullOrEmpty($registry)) {
+        $registry = "docker.io"
+    }
+
+    # Create a list of the tags that are required
+    $tags = @()
+    # $tags += (" -t {0}/{1}:latest" -f $registry, $name)
+
+    $image_name = "{0}/{1}:{2}-{3}" -f $registry, $name, $tag, $arch
+
+    # Login to the specified container registry
+    Write-Host ("Logging into registry: {0}" -f $registry)
+    Invoke-External -Command "docker login -u ${username} -p ${password} ${registry}" -Dryrun:$dryrun
+
+    if (![string]::IsNullOrEmpty($tag)) {
+        $tags += ("-t {0}" -f $image_name)
+    }
+
+    # Build up the arguments for the full command
+    $buildArgs = @(($tags -join " "))
+
+    if (![string]::IsNullOrEmpty($arguments)) {
+        $buildArgs += $arguments
+    }
+
+    # Build and push the image
+    Write-Host ("Building docker image: {0}" -f ($platform -join ","))
+    Write-Host "docker build $($buildArgs -join " ")"
+    Invoke-External -Command "docker build $($buildArgs -join " ")" -Dryrun:$dryrun
+
+    # Verify the image was built locally before attempting push
+    if (-not $dryrun.IsPresent) {
+        & docker image inspect $image_name *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw ("Docker build failed: image not found locally: {0}" -f $image_name)
+        }
+        Write-Host ("Verified image built locally: {0}" -f $image_name)
+    }
+
+    Write-Host ("Push docker image: {0}" -f $image_name)
+    Invoke-External -Command "docker push ${image_name}" -Dryrun:$dryrun
+
+    # Verify the image exists in the registry after push
+    if (-not $dryrun.IsPresent) {
+        Wait-ForDockerImagePush -Image $image_name -Retries $PushVerifyRetries -DelaySeconds $PushVerifyDelaySeconds
     }
 }
-
-# Define default values for parameters not set
-if ([string]::IsNullOrEmpty($registry)) {
-    $registry = "docker.io"
-}
-
-# Create a list of the tags that are required
-$tags = @()
-# $tags += (" -t {0}/{1}:latest" -f $registry, $name)
-
-$image_name = "{0}/{1}:{2}-{3}" -f $registry, $name, $tag, $arch
-
-# Login to the specified container registry
-Write-Host ("Logging into registry: {0}" -f $registry)
-Invoke-External -Command "docker login -u ${username} -p ${password} ${registry}" -Dryrun:$dryrun
-
-if (![string]::IsNullOrEmpty($tag)) {
-    $tags += ("-t {0}" -f $image_name)
-}
-
-# Build up the arguments for the full command
-$buildArgs = @(($tags -join " "))
-
-if (![string]::IsNullOrEmpty($arguments)) {
-    $buildArgs += $arguments
-}
-
-# Build and push the image
-Write-Host ("Building docker image: {0}" -f ($platform -join ","))
-Write-Host "docker build $($buildArgs -join " ")"
-Invoke-External -Command "docker build $($buildArgs -join " ")" -Dryrun:$dryrun
-
-# Verify the image was built locally before attempting push
-if (-not $dryrun.IsPresent) {
-    & docker image inspect $image_name *> $null
-    if ($LASTEXITCODE -ne 0) {
-        throw ("Docker build failed: image not found locally: {0}" -f $image_name)
-    }
-    Write-Host ("Verified image built locally: {0}" -f $image_name)
-}
-
-Write-Host ("Push docker image: {0}" -f $image_name)
-Invoke-External -Command "docker push ${image_name}" -Dryrun:$dryrun
-
-# Verify the image exists in the registry after push
-if (-not $dryrun.IsPresent) {
-    Wait-ForDockerImagePush -Image $image_name -Retries $PushVerifyRetries -DelaySeconds $PushVerifyDelaySeconds
+finally {
+    $ErrorActionPreference = $previousErrorActionPreference
 }

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -2,6 +2,7 @@
 [CmdletBinding()]
 param (
 
+    [ValidateSet("linux/amd64", "linux/arm64")]
     [string[]]
     # Platforms that the image should be built for
     $platform = @("linux/amd64"),
@@ -102,6 +103,9 @@ try {
         }
         "linux/arm64" {
             $arch = "arm64"
+        }
+        default {
+            throw ("Unsupported platform '{0}'. Supported values are linux/amd64 and linux/arm64." -f $platform)
         }
     }
 

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -32,8 +32,51 @@ param (
 
     [switch]
     # State that the script would run in dryrun and not to execute any commands
-    $dryrun
+    $dryrun,
+
+    [int]
+    # Number of times to verify image exists in registry after push
+    $PushVerifyRetries = 5,
+
+    [int]
+    # Delay in seconds between push verification attempts
+    $PushVerifyDelaySeconds = 10
 )
+
+$ErrorActionPreference = "Stop"
+
+function Wait-ForDockerImagePush {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Image,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $Retries,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $DelaySeconds
+    )
+
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+        & docker manifest inspect $Image *> $null
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host ("Verified image exists in registry: {0}" -f $Image)
+            return
+        }
+
+        if ($attempt -eq $Retries) {
+            & docker manifest inspect $Image
+            throw ("Image was not found in registry after push ({0} attempts): {1}" -f $Retries, $Image)
+        }
+
+        Write-Host ("Verifying image push ({0}/{1}): {2}" -f $attempt, $Retries, $Image)
+        Start-Sleep -Seconds $DelaySeconds
+    }
+}
 
 # Enable experimental builds
 $env:DOCKER_CLI_AKV2_EXPERIMENTAL="enabled"
@@ -79,5 +122,19 @@ Write-Host ("Building docker image: {0}" -f ($platform -join ","))
 Write-Host "docker build $($buildArgs -join " ")"
 Invoke-External -Command "docker build $($buildArgs -join " ")" -Dryrun:$dryrun
 
+# Verify the image was built locally before attempting push
+if (-not $dryrun.IsPresent) {
+    & docker image inspect $image_name *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Docker build failed: image not found locally: {0}" -f $image_name)
+    }
+    Write-Host ("Verified image built locally: {0}" -f $image_name)
+}
+
 Write-Host ("Push docker image: {0}" -f $image_name)
 Invoke-External -Command "docker push ${image_name}" -Dryrun:$dryrun
+
+# Verify the image exists in the registry after push
+if (-not $dryrun.IsPresent) {
+    Wait-ForDockerImagePush -Image $image_name -Retries $PushVerifyRetries -DelaySeconds $PushVerifyDelaySeconds
+}

--- a/build/scripts/Build-DockerImage.ps1
+++ b/build/scripts/Build-DockerImage.ps1
@@ -45,6 +45,8 @@ param (
     $PushVerifyDelaySeconds = 10
 )
 
+. (Join-Path $PSScriptRoot "RegistryManifestTools.ps1")
+
 $previousErrorActionPreference = $ErrorActionPreference
 
 function Wait-ForDockerImagePush {
@@ -59,23 +61,30 @@ function Wait-ForDockerImagePush {
 
         [Parameter(Mandatory = $true)]
         [int]
-        $DelaySeconds
+        $DelaySeconds,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Username,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password
     )
 
     for ($attempt = 1; $attempt -le $Retries; $attempt++) {
-        & docker manifest inspect $Image *> $null
+        $checkResult = Test-RegistryManifestAvailability -Image $Image -Username $Username -Password $Password
 
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host ("Verified image exists in registry: {0}" -f $Image)
+        if ($checkResult.Available) {
+            Write-Host ("Verified image exists in registry via {0}: {1}" -f $checkResult.Probe, $Image)
             return
         }
 
         if ($attempt -eq $Retries) {
-            & docker manifest inspect $Image
-            throw ("Image was not found in registry after push ({0} attempts): {1}" -f $Retries, $Image)
+            throw ("Image was not found in registry after push ({0} attempts via {1}): {2}. Last detail: {3}" -f $Retries, $checkResult.Probe, $Image, $checkResult.Detail)
         }
 
-        Write-Host ("Verifying image push ({0}/{1}): {2}" -f $attempt, $Retries, $Image)
+        Write-Host ("Verifying image push ({0}/{1}) via {2}: {3}" -f $attempt, $Retries, $checkResult.Probe, $Image)
         Start-Sleep -Seconds $DelaySeconds
     }
 }
@@ -141,7 +150,7 @@ try {
 
     # Verify the image exists in the registry after push
     if (-not $dryrun.IsPresent) {
-        Wait-ForDockerImagePush -Image $image_name -Retries $PushVerifyRetries -DelaySeconds $PushVerifyDelaySeconds
+        Wait-ForDockerImagePush -Image $image_name -Retries $PushVerifyRetries -DelaySeconds $PushVerifyDelaySeconds -Username $username -Password $password
     }
 }
 finally {

--- a/build/scripts/New-DockerManifest.ps1
+++ b/build/scripts/New-DockerManifest.ps1
@@ -61,6 +61,8 @@ param (
     $DocsPath
 )
 
+. (Join-Path $PSScriptRoot "RegistryManifestTools.ps1")
+
 function Wait-ForDockerManifest {
     param (
         [Parameter(Mandatory = $true)]
@@ -73,24 +75,30 @@ function Wait-ForDockerManifest {
 
         [Parameter(Mandatory = $true)]
         [int]
-        $DelaySeconds
+        $DelaySeconds,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Username,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password
     )
 
     for ($attempt = 1; $attempt -le $Retries; $attempt++) {
-        & docker manifest inspect $Image *> $null
+        $checkResult = Test-RegistryManifestAvailability -Image $Image -Username $Username -Password $Password
 
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host ("Found image manifest: {0}" -f $Image)
+        if ($checkResult.Available) {
+            Write-Host ("Found image manifest via {0}: {1}" -f $checkResult.Probe, $Image)
             return
         }
 
         if ($attempt -eq $Retries) {
-            # Emit inspect output once at the end to help diagnose registry propagation/auth issues in CI logs.
-            & docker manifest inspect $Image
-            throw ("Image manifest did not become available after {0} attempts: {1}" -f $Retries, $Image)
+            throw ("Image manifest did not become available after {0} attempts via {1}: {2}. Last detail: {3}" -f $Retries, $checkResult.Probe, $Image, $checkResult.Detail)
         }
 
-        Write-Host ("Waiting for image manifest ({0}/{1}): {2}" -f $attempt, $Retries, $Image)
+        Write-Host ("Waiting for image manifest ({0}/{1}) via {2}: {3}" -f $attempt, $Retries, $checkResult.Probe, $Image)
         Start-Sleep -Seconds $DelaySeconds
     }
 }
@@ -133,6 +141,8 @@ $ManifestCheckDelaySeconds = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANI
 
 Write-Host ("Manifest availability checks configured: retries={0}, delaySeconds={1}" -f $ManifestCheckRetries, $ManifestCheckDelaySeconds)
 
+$env:DOCKER_CLI_AKV2_EXPERIMENTAL="enabled"
+
 # Define default values for parameters not set
 if ([string]::IsNullOrEmpty($registry)) {
     $registry = "docker.io"
@@ -150,7 +160,7 @@ Invoke-External -Command "docker login -u $username -p $password $registry" -Dry
 
 if (-not $Dryrun.IsPresent) {
     foreach ($image in $images) {
-        Wait-ForDockerManifest -Image $image -Retries $ManifestCheckRetries -DelaySeconds $ManifestCheckDelaySeconds
+        Wait-ForDockerManifest -Image $image -Retries $ManifestCheckRetries -DelaySeconds $ManifestCheckDelaySeconds -Username $username -Password $password
     }
 }
 else {

--- a/build/scripts/New-DockerManifest.ps1
+++ b/build/scripts/New-DockerManifest.ps1
@@ -40,23 +40,99 @@ param (
     $password = $env:DOCKER_PASSWORD,
 
     [switch]
-    # State that the scritp whould run in dryrun and not to execute any commands
+    # State that the script would run in dryrun and not to execute any commands
     $Dryrun,
 
     [switch]
     # State if manifest should be tagged as Latest
     $Latest,
 
+    [int]
+    # Number of times to check whether source image manifests are visible
+    $ManifestCheckRetries = 24,
+
+    [int]
+    # Delay between manifest availability checks in seconds
+    $ManifestCheckDelaySeconds = 10,
+
     [string]
     $DocsPath
 )
+
+function Wait-ForDockerManifest {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Image,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $Retries,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $DelaySeconds
+    )
+
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+        & docker manifest inspect $Image *> $null
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host ("Found image manifest: {0}" -f $Image)
+            return
+        }
+
+        if ($attempt -eq $Retries) {
+            # Emit inspect output once at the end to help diagnose registry propagation/auth issues in CI logs.
+            & docker manifest inspect $Image
+            throw ("Image manifest did not become available after {0} attempts: {1}" -f $Retries, $Image)
+        }
+
+        Write-Host ("Waiting for image manifest ({0}/{1}): {2}" -f $attempt, $Retries, $Image)
+        Start-Sleep -Seconds $DelaySeconds
+    }
+}
+
+function Get-PositiveIntEnvOverride {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $EnvVarName,
+
+        [Parameter(Mandatory = $true)]
+        [int]
+        $CurrentValue
+    )
+
+    $rawValue = [Environment]::GetEnvironmentVariable($EnvVarName)
+    if ([string]::IsNullOrWhiteSpace($rawValue)) {
+        return $CurrentValue
+    }
+
+    $parsedValue = 0
+    if (-not [int]::TryParse($rawValue, [ref]$parsedValue)) {
+        throw ("Invalid value for {0}: '{1}'. Expected a positive integer." -f $EnvVarName, $rawValue)
+    }
+
+    if ($parsedValue -le 0) {
+        throw ("Invalid value for {0}: '{1}'. Value must be greater than zero." -f $EnvVarName, $rawValue)
+    }
+
+    return $parsedValue
+}
+
+# Allow retry behavior to be controlled from pipeline variables without changing taskctl invocation.
+$ManifestCheckRetries = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_RETRIES" -CurrentValue $ManifestCheckRetries
+$ManifestCheckDelaySeconds = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_DELAY_SECONDS" -CurrentValue $ManifestCheckDelaySeconds
+
+Write-Host ("Manifest availability checks configured: retries={0}, delaySeconds={1}" -f $ManifestCheckRetries, $ManifestCheckDelaySeconds)
 
 # Define default values for parameters not set
 if ([string]::IsNullOrEmpty($registry)) {
     $registry = "docker.io"
 }
 
-# Iterate around the tages and build up the list of images
+# Iterate around the tags and build up the list of images
 $images = @()
 foreach ($tag in $Tags) {
     $images += "{0}/{1}:{2}-{3}" -f $registry, $Name, $Version, $tag
@@ -66,13 +142,22 @@ foreach ($tag in $Tags) {
 Write-Host ("Logging into registry: {0}" -f $registry)
 Invoke-External -Command "docker login -u $username -p $password $registry" -Dryrun:$Dryrun
 
+if (-not $Dryrun.IsPresent) {
+    foreach ($image in $images) {
+        Wait-ForDockerManifest -Image $image -Retries $ManifestCheckRetries -DelaySeconds $ManifestCheckDelaySeconds
+    }
+}
+else {
+    Write-Host "Skipping manifest-availability checks in dry-run mode"
+}
+
 Invoke-External -Command "docker manifest create `"${registry}/${Name}:${Version}`" $($images -join " ")" -Dryrun:$Dryrun
 
 # Now push the manifest to the registry
 Invoke-External -Command "docker manifest push `"${registry}/${Name}:${Version}`"" -Dryrun:$Dryrun
 
 if ($Latest.IsPresent) {
-    # Tag manifest with the latest tage
+    # Tag manifest with the latest tag
     Invoke-External -Command "docker manifest create `"${registry}/${Name}:latest`" $($images -join " ")" -Dryrun:$Dryrun
 
     Invoke-External -Command "docker manifest push `"${registry}/${Name}:latest`"" -Dryrun:$Dryrun

--- a/build/scripts/New-DockerManifest.ps1
+++ b/build/scripts/New-DockerManifest.ps1
@@ -154,36 +154,45 @@ foreach ($tag in $Tags) {
     $images += "{0}/{1}:{2}-{3}" -f $registry, $Name, $Version, $tag
 }
 
-# Login to the specified container registry
-Write-Host ("Logging into registry: {0}" -f $registry)
-Invoke-External -Command "docker login -u $username -p $password $registry" -Dryrun:$Dryrun
+$loggedIn = $false
+try {
+    if (-not $Dryrun.IsPresent) {
+        foreach ($image in $images) {
+            Wait-ForDockerManifest -Image $image -Retries $ManifestCheckRetries -DelaySeconds $ManifestCheckDelaySeconds -Username $username -Password $password
+        }
+    }
+    else {
+        Write-Host "Skipping manifest-availability checks in dry-run mode"
+    }
 
-if (-not $Dryrun.IsPresent) {
-    foreach ($image in $images) {
-        Wait-ForDockerManifest -Image $image -Retries $ManifestCheckRetries -DelaySeconds $ManifestCheckDelaySeconds -Username $username -Password $password
+    # Login to the specified container registry after availability checks.
+    Write-Host ("Logging into registry: {0}" -f $registry)
+    Invoke-DockerRegistryLogin -Registry $registry -Username $username -Password $password -Dryrun:$Dryrun
+    $loggedIn = -not $Dryrun.IsPresent
+
+    Invoke-External -Command "docker manifest create `"${registry}/${Name}:${Version}`" $($images -join " ")" -Dryrun:$Dryrun
+
+    # Now push the manifest to the registry
+    Invoke-External -Command "docker manifest push `"${registry}/${Name}:${Version}`"" -Dryrun:$Dryrun
+
+    if ($Latest.IsPresent) {
+        # Tag manifest with the latest tag
+        Invoke-External -Command "docker manifest create `"${registry}/${Name}:latest`" $($images -join " ")" -Dryrun:$Dryrun
+
+        Invoke-External -Command "docker manifest push `"${registry}/${Name}:latest`"" -Dryrun:$Dryrun
+    }
+
+    # Push the readme if the registry is docker.io
+    if ($registry -ieq "docker.io") {
+        $path_parts = $DocsPath -split "/"
+        $readme_path = [IO.Path]::Combine("markdown", [IO.Path]::Combine([IO.Path]::Combine($path_parts), "README.md"))
+
+        Write-Host ("Pushing README file: {0}" -f $readme_path)
+        Invoke-External -Command "docker pushrm --provider dockerhub ${registry}/${name} --file ${readme_path}" -Dryrun:$Dryrun
     }
 }
-else {
-    Write-Host "Skipping manifest-availability checks in dry-run mode"
-}
-
-Invoke-External -Command "docker manifest create `"${registry}/${Name}:${Version}`" $($images -join " ")" -Dryrun:$Dryrun
-
-# Now push the manifest to the registry
-Invoke-External -Command "docker manifest push `"${registry}/${Name}:${Version}`"" -Dryrun:$Dryrun
-
-if ($Latest.IsPresent) {
-    # Tag manifest with the latest tag
-    Invoke-External -Command "docker manifest create `"${registry}/${Name}:latest`" $($images -join " ")" -Dryrun:$Dryrun
-
-    Invoke-External -Command "docker manifest push `"${registry}/${Name}:latest`"" -Dryrun:$Dryrun
-}
-
-# Push the readme if the registry is docker.io
-if ($registry -ieq "docker.io") {
-    $path_parts = $DocsPath -split "/"
-    $readme_path = [IO.Path]::Combine("markdown", [IO.Path]::Combine([IO.Path]::Combine($path_parts), "README.md"))
-
-    Write-Host ("Pushing README file: {0}" -f $readme_path)
-    Invoke-External -Command "docker pushrm --provider dockerhub ${registry}/${name} --file ${readme_path}" -Dryrun:$Dryrun
+finally {
+    if ($loggedIn) {
+        Invoke-DockerRegistryLogout -Registry $registry
+    }
 }

--- a/build/scripts/New-DockerManifest.ps1
+++ b/build/scripts/New-DockerManifest.ps1
@@ -47,10 +47,12 @@ param (
     # State if manifest should be tagged as Latest
     $Latest,
 
+    [ValidateRange(1, [int]::MaxValue)]
     [int]
     # Number of times to check whether source image manifests are visible
     $ManifestCheckRetries = 24,
 
+    [ValidateRange(0, [int]::MaxValue)]
     [int]
     # Delay between manifest availability checks in seconds
     $ManifestCheckDelaySeconds = 10,
@@ -101,6 +103,10 @@ function Get-PositiveIntEnvOverride {
 
         [Parameter(Mandatory = $true)]
         [int]
+        $MinimumValue,
+
+        [Parameter(Mandatory = $true)]
+        [int]
         $CurrentValue
     )
 
@@ -111,19 +117,19 @@ function Get-PositiveIntEnvOverride {
 
     $parsedValue = 0
     if (-not [int]::TryParse($rawValue, [ref]$parsedValue)) {
-        throw ("Invalid value for {0}: '{1}'. Expected a positive integer." -f $EnvVarName, $rawValue)
+        throw ("Invalid value for {0}: '{1}'. Expected an integer greater than or equal to {2}." -f $EnvVarName, $rawValue, $MinimumValue)
     }
 
-    if ($parsedValue -le 0) {
-        throw ("Invalid value for {0}: '{1}'. Value must be greater than zero." -f $EnvVarName, $rawValue)
+    if ($parsedValue -lt $MinimumValue) {
+        throw ("Invalid value for {0}: '{1}'. Value must be greater than or equal to {2}." -f $EnvVarName, $rawValue, $MinimumValue)
     }
 
     return $parsedValue
 }
 
 # Allow retry behavior to be controlled from pipeline variables without changing taskctl invocation.
-$ManifestCheckRetries = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_RETRIES" -CurrentValue $ManifestCheckRetries
-$ManifestCheckDelaySeconds = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_DELAY_SECONDS" -CurrentValue $ManifestCheckDelaySeconds
+$ManifestCheckRetries = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_RETRIES" -MinimumValue 1 -CurrentValue $ManifestCheckRetries
+$ManifestCheckDelaySeconds = Get-PositiveIntEnvOverride -EnvVarName "DOCKER_MANIFEST_CHECK_DELAY_SECONDS" -MinimumValue 0 -CurrentValue $ManifestCheckDelaySeconds
 
 Write-Host ("Manifest availability checks configured: retries={0}, delaySeconds={1}" -f $ManifestCheckRetries, $ManifestCheckDelaySeconds)
 

--- a/build/scripts/RegistryManifestTools.ps1
+++ b/build/scripts/RegistryManifestTools.ps1
@@ -60,53 +60,47 @@ function Test-AcrImageAvailability {
 
     $fullImageReference = "{0}/{1}" -f $ImageParts.Registry, $acrImage
 
-    $loginOutput = ""
-    try {
-        $loginOutput = ($Password | & docker login $ImageParts.Registry --username $Username --password-stdin 2>&1 | Out-String).Trim()
-        $loginExitCode = $LASTEXITCODE
+    $loginOutput = ($Password | & docker login $ImageParts.Registry --username $Username --password-stdin 2>&1 | Out-String).Trim()
+    $loginExitCode = $LASTEXITCODE
 
-        if ($loginExitCode -ne 0) {
-            if ([string]::IsNullOrWhiteSpace($loginOutput)) {
-                $loginOutput = "docker login exited with code {0}" -f $loginExitCode
-            }
-
-            throw ("Failed to authenticate to ACR '{0}': {1}" -f $ImageParts.Registry, $loginOutput)
+    if ($loginExitCode -ne 0) {
+        if ([string]::IsNullOrWhiteSpace($loginOutput)) {
+            $loginOutput = "docker login exited with code {0}" -f $loginExitCode
         }
 
-        $commandOutput = (& docker manifest inspect $fullImageReference 2>&1 | Out-String).Trim()
-        $exitCode = $LASTEXITCODE
+        throw ("Failed to authenticate to ACR '{0}': {1}" -f $ImageParts.Registry, $loginOutput)
+    }
 
-        if ($exitCode -eq 0) {
-            return [pscustomobject]@{
-                Available = $true
-                Probe     = "docker manifest inspect"
-                Reason    = "Available"
-                Detail    = "Resolved image reference in ACR"
-            }
-        }
+    $commandOutput = (& docker manifest inspect $fullImageReference 2>&1 | Out-String).Trim()
+    $exitCode = $LASTEXITCODE
 
-        if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied|requested access to the resource is denied|no basic auth credentials") {
-            throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
-        }
-
-        $reason = "Transient"
-        if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found|no such manifest") {
-            $reason = "NotFound"
-        }
-
-        if ([string]::IsNullOrWhiteSpace($commandOutput)) {
-            $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
-        }
-
+    if ($exitCode -eq 0) {
         return [pscustomobject]@{
-            Available = $false
+            Available = $true
             Probe     = "docker manifest inspect"
-            Reason    = $reason
-            Detail    = $commandOutput
+            Reason    = "Available"
+            Detail    = "Resolved image reference in ACR"
         }
     }
-    finally {
-        & docker logout $ImageParts.Registry *> $null
+
+    if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied|requested access to the resource is denied|no basic auth credentials") {
+        throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
+    }
+
+    $reason = "Transient"
+    if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found|no such manifest") {
+        $reason = "NotFound"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($commandOutput)) {
+        $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
+    }
+
+    return [pscustomobject]@{
+        Available = $false
+        Probe     = "docker manifest inspect"
+        Reason    = $reason
+        Detail    = $commandOutput
     }
 }
 

--- a/build/scripts/RegistryManifestTools.ps1
+++ b/build/scripts/RegistryManifestTools.ps1
@@ -1,0 +1,176 @@
+function Get-ContainerImageReferenceParts {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Image
+    )
+
+    $separatorIndex = $Image.IndexOf("/")
+    if ($separatorIndex -lt 0) {
+        throw ("Image reference must include a registry and repository: {0}" -f $Image)
+    }
+
+    $registry = $Image.Substring(0, $separatorIndex)
+    $remainder = $Image.Substring($separatorIndex + 1)
+
+    $digestSeparatorIndex = $remainder.IndexOf("@")
+    if ($digestSeparatorIndex -ge 0) {
+        return [pscustomobject]@{
+            Registry      = $registry
+            Repository    = $remainder.Substring(0, $digestSeparatorIndex)
+            Reference     = $remainder.Substring($digestSeparatorIndex + 1)
+            ReferenceKind = "digest"
+        }
+    }
+
+    $tagSeparatorIndex = $remainder.LastIndexOf(":")
+    if ($tagSeparatorIndex -lt 0) {
+        throw ("Image reference must include a tag or digest: {0}" -f $Image)
+    }
+
+    return [pscustomobject]@{
+        Registry      = $registry
+        Repository    = $remainder.Substring(0, $tagSeparatorIndex)
+        Reference     = $remainder.Substring($tagSeparatorIndex + 1)
+        ReferenceKind = "tag"
+    }
+}
+
+function Get-AcrRegistryName {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Registry
+    )
+
+    if ($Registry -notlike "*.azurecr.io") {
+        throw ("Registry is not an Azure Container Registry login server: {0}" -f $Registry)
+    }
+
+    return $Registry.Substring(0, $Registry.IndexOf(".azurecr.io"))
+}
+
+function Test-AcrImageAvailability {
+    param (
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]
+        $ImageParts,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Username,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password
+    )
+
+    $acrName = Get-AcrRegistryName -Registry $ImageParts.Registry
+    $acrImage = if ($ImageParts.ReferenceKind -eq "digest") {
+        "{0}@{1}" -f $ImageParts.Repository, $ImageParts.Reference
+    }
+    else {
+        "{0}:{1}" -f $ImageParts.Repository, $ImageParts.Reference
+    }
+
+    $commandOutput = (& az acr repository show --name $acrName --image $acrImage --username $Username --password $Password --output none --only-show-errors 2>&1 | Out-String).Trim()
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        return [pscustomobject]@{
+            Available = $true
+            Probe     = "az acr repository show"
+            Reason    = "Available"
+            Detail    = "Resolved image reference in ACR"
+        }
+    }
+
+    if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied") {
+        throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
+    }
+
+    $reason = "Transient"
+    if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found") {
+        $reason = "NotFound"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($commandOutput)) {
+        $commandOutput = "Azure CLI exited with code {0}" -f $exitCode
+    }
+
+    return [pscustomobject]@{
+        Available = $false
+        Probe     = "az acr repository show"
+        Reason    = $reason
+        Detail    = $commandOutput
+    }
+}
+
+function Test-DockerManifestAvailability {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Image
+    )
+
+    $commandOutput = (& docker manifest inspect $Image 2>&1 | Out-String).Trim()
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        return [pscustomobject]@{
+            Available = $true
+            Probe     = "docker manifest inspect"
+            Reason    = "Available"
+            Detail    = "Resolved image reference with docker"
+        }
+    }
+
+    if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied") {
+        throw ("Failed to query registry for '{0}': {1}" -f $Image, $commandOutput)
+    }
+
+    $reason = "Transient"
+    if ($commandOutput -match "(?i)manifest.*unknown|no such manifest|not found|name_unknown") {
+        $reason = "NotFound"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($commandOutput)) {
+        $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
+    }
+
+    return [pscustomobject]@{
+        Available = $false
+        Probe     = "docker manifest inspect"
+        Reason    = $reason
+        Detail    = $commandOutput
+    }
+}
+
+function Test-RegistryManifestAvailability {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Image,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Username,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password
+    )
+
+    $imageParts = Get-ContainerImageReferenceParts -Image $Image
+    $azCommand = Get-Command -Name az -ErrorAction SilentlyContinue
+
+    if ($imageParts.Registry -like "*.azurecr.io" -and $null -ne $azCommand) {
+        return Test-AcrImageAvailability -ImageParts $imageParts -Username $Username -Password $Password
+    }
+
+    if ($imageParts.Registry -like "*.azurecr.io" -and $null -eq $azCommand) {
+        Write-Host ("Azure CLI is not available; falling back to docker manifest inspection for {0}" -f $Image)
+    }
+
+    return Test-DockerManifestAvailability -Image $Image
+}

--- a/build/scripts/RegistryManifestTools.ps1
+++ b/build/scripts/RegistryManifestTools.ps1
@@ -36,6 +36,51 @@ function Get-ContainerImageReferenceParts {
     }
 }
 
+function Invoke-DockerRegistryLogin {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Registry,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Username,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password,
+
+        [switch]
+        $Dryrun
+    )
+
+    if ($Dryrun.IsPresent) {
+        Invoke-External -Command "docker login -u $Username --password-stdin $Registry" -Dryrun:$Dryrun
+        return
+    }
+
+    $loginOutput = ($Password | & docker login $Registry --username $Username --password-stdin 2>&1 | Out-String).Trim()
+    $loginExitCode = $LASTEXITCODE
+
+    if ($loginExitCode -ne 0) {
+        if ([string]::IsNullOrWhiteSpace($loginOutput)) {
+            $loginOutput = "docker login exited with code {0}" -f $loginExitCode
+        }
+
+        throw ("Failed to authenticate to registry '{0}': {1}" -f $Registry, $loginOutput)
+    }
+}
+
+function Invoke-DockerRegistryLogout {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Registry
+    )
+
+    $null = (& docker logout $Registry 2>&1 | Out-String)
+}
+
 function Test-AcrImageAvailability {
     param (
         [Parameter(Mandatory = $true)]
@@ -60,47 +105,47 @@ function Test-AcrImageAvailability {
 
     $fullImageReference = "{0}/{1}" -f $ImageParts.Registry, $acrImage
 
-    $loginOutput = ($Password | & docker login $ImageParts.Registry --username $Username --password-stdin 2>&1 | Out-String).Trim()
-    $loginExitCode = $LASTEXITCODE
+    $loggedIn = $false
+    try {
+        Invoke-DockerRegistryLogin -Registry $ImageParts.Registry -Username $Username -Password $Password
+        $loggedIn = $true
 
-    if ($loginExitCode -ne 0) {
-        if ([string]::IsNullOrWhiteSpace($loginOutput)) {
-            $loginOutput = "docker login exited with code {0}" -f $loginExitCode
+        $commandOutput = (& docker manifest inspect $fullImageReference 2>&1 | Out-String).Trim()
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -eq 0) {
+            return [pscustomobject]@{
+                Available = $true
+                Probe     = "docker manifest inspect"
+                Reason    = "Available"
+                Detail    = "Resolved image reference in ACR"
+            }
         }
 
-        throw ("Failed to authenticate to ACR '{0}': {1}" -f $ImageParts.Registry, $loginOutput)
-    }
+        if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied|requested access to the resource is denied|no basic auth credentials") {
+            throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
+        }
 
-    $commandOutput = (& docker manifest inspect $fullImageReference 2>&1 | Out-String).Trim()
-    $exitCode = $LASTEXITCODE
+        $reason = "Transient"
+        if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found|no such manifest") {
+            $reason = "NotFound"
+        }
 
-    if ($exitCode -eq 0) {
+        if ([string]::IsNullOrWhiteSpace($commandOutput)) {
+            $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
+        }
+
         return [pscustomobject]@{
-            Available = $true
+            Available = $false
             Probe     = "docker manifest inspect"
-            Reason    = "Available"
-            Detail    = "Resolved image reference in ACR"
+            Reason    = $reason
+            Detail    = $commandOutput
         }
     }
-
-    if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied|requested access to the resource is denied|no basic auth credentials") {
-        throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
-    }
-
-    $reason = "Transient"
-    if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found|no such manifest") {
-        $reason = "NotFound"
-    }
-
-    if ([string]::IsNullOrWhiteSpace($commandOutput)) {
-        $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
-    }
-
-    return [pscustomobject]@{
-        Available = $false
-        Probe     = "docker manifest inspect"
-        Reason    = $reason
-        Detail    = $commandOutput
+    finally {
+        if ($loggedIn) {
+            Invoke-DockerRegistryLogout -Registry $ImageParts.Registry
+        }
     }
 }
 

--- a/build/scripts/RegistryManifestTools.ps1
+++ b/build/scripts/RegistryManifestTools.ps1
@@ -36,20 +36,6 @@ function Get-ContainerImageReferenceParts {
     }
 }
 
-function Get-AcrRegistryName {
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]
-        $Registry
-    )
-
-    if ($Registry -notlike "*.azurecr.io") {
-        throw ("Registry is not an Azure Container Registry login server: {0}" -f $Registry)
-    }
-
-    return $Registry.Substring(0, $Registry.IndexOf(".azurecr.io"))
-}
-
 function Test-AcrImageAvailability {
     param (
         [Parameter(Mandatory = $true)]
@@ -65,7 +51,6 @@ function Test-AcrImageAvailability {
         $Password
     )
 
-    $acrName = Get-AcrRegistryName -Registry $ImageParts.Registry
     $acrImage = if ($ImageParts.ReferenceKind -eq "digest") {
         "{0}@{1}" -f $ImageParts.Repository, $ImageParts.Reference
     }
@@ -73,36 +58,55 @@ function Test-AcrImageAvailability {
         "{0}:{1}" -f $ImageParts.Repository, $ImageParts.Reference
     }
 
-    $commandOutput = (& az acr repository show --name $acrName --image $acrImage --username $Username --password $Password --output none --only-show-errors 2>&1 | Out-String).Trim()
-    $exitCode = $LASTEXITCODE
+    $fullImageReference = "{0}/{1}" -f $ImageParts.Registry, $acrImage
 
-    if ($exitCode -eq 0) {
+    $loginOutput = ""
+    try {
+        $loginOutput = ($Password | & docker login $ImageParts.Registry --username $Username --password-stdin 2>&1 | Out-String).Trim()
+        $loginExitCode = $LASTEXITCODE
+
+        if ($loginExitCode -ne 0) {
+            if ([string]::IsNullOrWhiteSpace($loginOutput)) {
+                $loginOutput = "docker login exited with code {0}" -f $loginExitCode
+            }
+
+            throw ("Failed to authenticate to ACR '{0}': {1}" -f $ImageParts.Registry, $loginOutput)
+        }
+
+        $commandOutput = (& docker manifest inspect $fullImageReference 2>&1 | Out-String).Trim()
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -eq 0) {
+            return [pscustomobject]@{
+                Available = $true
+                Probe     = "docker manifest inspect"
+                Reason    = "Available"
+                Detail    = "Resolved image reference in ACR"
+            }
+        }
+
+        if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied|requested access to the resource is denied|no basic auth credentials") {
+            throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
+        }
+
+        $reason = "Transient"
+        if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found|no such manifest") {
+            $reason = "NotFound"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($commandOutput)) {
+            $commandOutput = "docker manifest inspect exited with code {0}" -f $exitCode
+        }
+
         return [pscustomobject]@{
-            Available = $true
-            Probe     = "az acr repository show"
-            Reason    = "Available"
-            Detail    = "Resolved image reference in ACR"
+            Available = $false
+            Probe     = "docker manifest inspect"
+            Reason    = $reason
+            Detail    = $commandOutput
         }
     }
-
-    if ($commandOutput -match "(?i)unauthorized|authentication|authorization|denied") {
-        throw ("Failed to query ACR for '{0}': {1}" -f $acrImage, $commandOutput)
-    }
-
-    $reason = "Transient"
-    if ($commandOutput -match "(?i)manifest.*unknown|not found|does not exist|name_unknown|repository.*not found") {
-        $reason = "NotFound"
-    }
-
-    if ([string]::IsNullOrWhiteSpace($commandOutput)) {
-        $commandOutput = "Azure CLI exited with code {0}" -f $exitCode
-    }
-
-    return [pscustomobject]@{
-        Available = $false
-        Probe     = "az acr repository show"
-        Reason    = $reason
-        Detail    = $commandOutput
+    finally {
+        & docker logout $ImageParts.Registry *> $null
     }
 }
 
@@ -162,14 +166,9 @@ function Test-RegistryManifestAvailability {
     )
 
     $imageParts = Get-ContainerImageReferenceParts -Image $Image
-    $azCommand = Get-Command -Name az -ErrorAction SilentlyContinue
 
-    if ($imageParts.Registry -like "*.azurecr.io" -and $null -ne $azCommand) {
+    if ($imageParts.Registry -like "*.azurecr.io") {
         return Test-AcrImageAvailability -ImageParts $imageParts -Username $Username -Password $Password
-    }
-
-    if ($imageParts.Registry -like "*.azurecr.io" -and $null -eq $azCommand) {
-        Write-Host ("Azure CLI is not available; falling back to docker manifest inspection for {0}" -f $Image)
     }
 
     return Test-DockerManifestAvailability -Image $Image

--- a/docs/docker-definitions/golang.adoc
+++ b/docs/docker-definitions/golang.adoc
@@ -17,8 +17,9 @@ Image that contains the Go program,ming language, which is used to build Ensono 
 |====
 | Type | Name | Version | URL
 | Binary | Go | 1.26.2 | https://go.dev/dl/#go1.26.2
-| Library | go-junit-report | latest | https://github.com/jstemmer/go-junit-report
-| Library | gocover-cobertura | latest | https://github.com/t-yuki/gocover-cobertura@latest
-| Library | gocov-xml | latest | https://github.com/AlekSi/gocov-xml@latest
-| Binary | gocyclo | latest | https://github.com/fzipp/gocyclo
+| Library | go-junit-report | 1.0.0 | https://github.com/jstemmer/go-junit-report/releases/tag/v1.0.0
+| Library | gocover-cobertura | 20180217150009-aaee18c8195c | https://github.com/t-yuki/gocover-cobertura/tree/aaee18c8195c
+| Library | gocov-xml | 1.2.0 | https://github.com/AlekSi/gocov-xml/releases/tag/v1.2.0
+| Binary | gocyclo | 0.6.0 | https://github.com/fzipp/gocyclo/releases/tag/v0.6.0
+| Binary | govulncheck | 1.2.0 | https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
 |====

--- a/docs/docker-definitions/golang.adoc
+++ b/docs/docker-definitions/golang.adoc
@@ -16,7 +16,7 @@ Image that contains the Go program,ming language, which is used to build Ensono 
 [cols="1,2,1,2",options=header]
 |====
 | Type | Name | Version | URL
-| Binary | Go | 1.26.2 | https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+| Binary | Go | 1.26.2 | https://go.dev/dl/#go1.26.2
 | Library | go-junit-report | latest | https://github.com/jstemmer/go-junit-report
 | Library | gocover-cobertura | latest | https://github.com/t-yuki/gocover-cobertura@latest
 | Library | gocov | latest | https://github.com/axw/gocov/gocov@latest

--- a/docs/docker-definitions/golang.adoc
+++ b/docs/docker-definitions/golang.adoc
@@ -16,7 +16,7 @@ Image that contains the Go program,ming language, which is used to build Ensono 
 [cols="1,2,1,2",options=header]
 |====
 | Type | Name | Version | URL
-| Binary | Go | 1.21.5 | https://go.dev/dl/go1.21.5.linux-amd64.tar.gz
+| Binary | Go | 1.26.2 | https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
 | Library | go-junit-report | latest | https://github.com/jstemmer/go-junit-report
 | Library | gocover-cobertura | latest | https://github.com/t-yuki/gocover-cobertura@latest
 | Library | gocov | latest | https://github.com/axw/gocov/gocov@latest

--- a/docs/docker-definitions/golang.adoc
+++ b/docs/docker-definitions/golang.adoc
@@ -19,6 +19,6 @@ Image that contains the Go program,ming language, which is used to build Ensono 
 | Binary | Go | 1.26.2 | https://go.dev/dl/#go1.26.2
 | Library | go-junit-report | latest | https://github.com/jstemmer/go-junit-report
 | Library | gocover-cobertura | latest | https://github.com/t-yuki/gocover-cobertura@latest
-| Library | gocov | latest | https://github.com/axw/gocov/gocov@latest
 | Library | gocov-xml | latest | https://github.com/AlekSi/gocov-xml@latest
+| Binary | gocyclo | latest | https://github.com/fzipp/gocyclo
 |====

--- a/src/definitions/golang/Dockerfile.ubuntu
+++ b/src/definitions/golang/Dockerfile.ubuntu
@@ -4,7 +4,7 @@ ARG ORG=ensono
 
 FROM ${REGISTRY}/${ORG}/eir-foundation-powershell:${IMAGE_TAG}
 
-ARG GOLANG_VERSION=1.21.5
+ARG GOLANG_VERSION=1.26.2
 ARG TIMEZONE="Europe/London"
 
 # Copy the install script over and then run it

--- a/src/definitions/golang/files/install.bash
+++ b/src/definitions/golang/files/install.bash
@@ -2,6 +2,12 @@
 
 set -euxo pipefail
 
+GO_JUNIT_REPORT_VERSION="v1.0.0"
+GOCOVER_COBERTURA_VERSION="v0.0.0-20180217150009-aaee18c8195c"
+GOCOV_XML_VERSION="v1.2.0"
+GOCYCLO_VERSION="v0.6.0"
+GOVULNCHECK_VERSION="v1.2.0"
+
 retry_command() {
 	local retries="$1"
 	local delay_seconds="$2"
@@ -56,9 +62,12 @@ tar zxf /tmp/golang.tar.gz -C /usr/local
 rm -rf /tmp/*
 
 # Install the necessary packages to run unit tests for Stacks projects
-install_go_tool github.com/jstemmer/go-junit-report@latest
-install_go_tool github.com/t-yuki/gocover-cobertura@latest
-install_go_tool github.com/AlekSi/gocov-xml@latest
+install_go_tool github.com/jstemmer/go-junit-report@${GO_JUNIT_REPORT_VERSION}
+install_go_tool github.com/t-yuki/gocover-cobertura@${GOCOVER_COBERTURA_VERSION}
+install_go_tool github.com/AlekSi/gocov-xml@${GOCOV_XML_VERSION}
 
 # Install gocyclo for code complexity analysis
-install_go_tool github.com/fzipp/gocyclo/cmd/gocyclo@latest
+install_go_tool github.com/fzipp/gocyclo/cmd/gocyclo@${GOCYCLO_VERSION}
+
+# Install govulncheck for Go vulnerability scanning
+install_go_tool golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}

--- a/src/definitions/golang/files/install.bash
+++ b/src/definitions/golang/files/install.bash
@@ -2,24 +2,63 @@
 
 set -euxo pipefail
 
+retry_command() {
+	local retries="$1"
+	local delay_seconds="$2"
+	shift 2
+
+	local attempt=1
+	while [ "$attempt" -le "$retries" ]
+	do
+		if "$@"
+		then
+			return 0
+		fi
+
+		if [ "$attempt" -eq "$retries" ]
+		then
+			return 1
+		fi
+
+		echo "Command failed on attempt ${attempt}/${retries}. Retrying in ${delay_seconds}s: $*"
+		sleep "$delay_seconds"
+		attempt=$((attempt + 1))
+	done
+}
+
+install_go_tool() {
+	local module="$1"
+
+	# Prefer the default Go module resolution first.
+	if retry_command 4 5 /usr/local/go/bin/go install "${module}"
+	then
+		return 0
+	fi
+
+	# Fallback for environments where the default module proxy is unavailable.
+	retry_command 4 5 env GOPROXY=direct GOSUMDB=off /usr/local/go/bin/go install "${module}"
+}
+
 # Determine the architecture of the image
 . /usr/local/bin/platform.bash
 
-# Update APT and install nessary packages
+# Update APT and install necessary packages
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata unzip curl
+DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata unzip curl ca-certificates
 unlink /etc/localtime
 ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
 
 # Download the specified version of GO
-curl --fail-with-body -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${BIN_ARCH}.tar.gz -o /tmp/golang.tar.gz
+retry_command 4 5 curl --fail-with-body -L https://go.dev/dl/go${GOLANG_VERSION}.linux-${BIN_ARCH}.tar.gz -o /tmp/golang.tar.gz
 tar zxf /tmp/golang.tar.gz -C /usr/local
 
 # Remove downloaded
 rm -rf /tmp/*
 
-# Install the necssary pacakges to run unitests for Stacks projects
-/usr/local/go/bin/go install github.com/jstemmer/go-junit-report@latest
-/usr/local/go/bin/go install github.com/t-yuki/gocover-cobertura@latest
-/usr/local/go/bin/go install github.com/axw/gocov/gocov@latest
-/usr/local/go/bin/go install github.com/AlekSi/gocov-xml@latest
+# Install the necessary packages to run unit tests for Stacks projects
+install_go_tool github.com/jstemmer/go-junit-report@latest
+install_go_tool github.com/t-yuki/gocover-cobertura@latest
+install_go_tool github.com/AlekSi/gocov-xml@latest
+
+# Install gocyclo for code complexity analysis
+install_go_tool github.com/fzipp/gocyclo/cmd/gocyclo@latest

--- a/src/definitions/golang/files/install.bash
+++ b/src/definitions/golang/files/install.bash
@@ -42,7 +42,7 @@ install_go_tool() {
 	fi
 
 	# Fallback for environments where the default module proxy is unavailable.
-	retry_command 4 5 env GOPROXY=direct GOSUMDB=off /usr/local/go/bin/go install "${module}"
+	retry_command 4 5 env GOPROXY=direct /usr/local/go/bin/go install "${module}"
 }
 
 # Determine the architecture of the image


### PR DESCRIPTION
## Summary
- add post-build local image verification in Build-DockerImage.ps1
- add post-push registry verification with retry logic before manifest creation can proceed
- make the create_manifest job explicitly require successful build jobs
- update Go version to 1.26.2 in src/definitions/golang/Dockerfile.ubuntu to restore the golang image stage (1.21.5 is no longer available upstream)
- add .github/prompts/address-pr-comments.prompt.md agent prompt for reviewing and addressing PR comments (workflow tooling, not product code)

## Why
This mitigates silent docker build/push failures caused by PowerShell command execution behavior that can mask non-zero exit codes, which then allows the manifest job to run before the arch-specific image is actually available.

The Go bump restores golang image builds after upstream removal of the previously pinned version.

The agent prompt is included here as it was developed alongside this PR to help manage the review process. It contains no secrets or sensitive data and does not affect the build pipeline.

## Validation
- reviewed the build and manifest pipeline flow end-to-end
- verified the build script now fails fast if the local image is missing after build
- verified the build script now fails if the pushed image does not become visible in the registry
- confirmed the manifest job has an explicit succeeded() condition